### PR TITLE
Fixed token expiration issue when posting the new playlist to spotify…

### DIFF
--- a/client/components/guestListItem.jsx
+++ b/client/components/guestListItem.jsx
@@ -13,14 +13,18 @@ const GuestListItem = ({ user, eventId }) => {
   let attending;
   let status;
   let color;
-  user.eventUser.isAttending === true ? attending = 'thumbs up' : attending = 'thumbs down'
-  user.eventUser.isAttending === true ? status = 'Attending' : status = 'Currently Not Attending'
-  user.eventUser.isAttending === true ? color = 'green' : color = 'red'
-
+  if(user.eventUser) {
+    user.eventUser.isAttending === true ? attending = 'thumbs up' : attending = 'thumbs down'
+    user.eventUser.isAttending === true ? status = 'Attending' : status = 'Currently Not Attending'
+    user.eventUser.isAttending === true ? color = 'green' : color = 'red'
+  } else {
+    attending = 'thumbs down'
+    status = 'Currently not attending'
+    color = 'red'
+  }
   return (
 
         <Card raised = {true }color="purple">
-
           <Image src={user.imgurPhoto} alt={`${user.name}'s Photo`} />
           <Card.Content color="purple">
             <Card.Header>{user.name}</Card.Header>

--- a/client/components/partyView.jsx
+++ b/client/components/partyView.jsx
@@ -61,19 +61,12 @@ class PartyView extends React.Component {
 
 
   render() {
-    // console.log('songsData', this.state.songsData)
-    // console.log('ARTISTS TOP TRACKS', this.state.topArtistSongs);
-    // console.log('ALL SONGS', this.state.songs);
-    // console.log('ID ARR', this.state.idArr)
-    // console.log('TOP ARTIST SONGS ON STATE', this.state.topArtistSongs)
-    // console.log('SONGS DATA FINALLY', this.state.songsData)
-    // console.log('ARTIST GENRES', this.state.genres)
-
     const { user, eventId, guestlist, event, spotifyPlaylist, startParty, eventStatus } = this.props
     const { isHost, isCheckedIn } = this.state
     const { hasStarted } = event
     let spotifyUri = this.props.spotifyPlaylist.spotifyPlaylistUri;
     let spotifyUrl
+    spotifyUri ? spotifyUrl = spotifyUri.replace(/:/g, '/').substr(8) : spotifyUri = spotifyUri + '';
 
     socket.on(`userHere/${eventId}`, (userId, eventId) => {
       console.log("RECEIVED EMITTER! eventID:", eventId, "userId", userId)
@@ -82,13 +75,7 @@ class PartyView extends React.Component {
         this.props.updatePlaylist(+eventId)
       }
     })
-    // console.log(event, hasStarted, "Event Status")
-    // this.setState({spotifyUri: spotifyUri})
-    spotifyUri ? spotifyUrl = spotifyUri.replace(/:/g, '/').substr(8) : spotifyUri = spotifyUri + '';
-    // console.log('EVENTTT', this.props.event)
-    // console.log('GUESTLISTTTTT', this.props.guestlist)
-    // console.log('SPOTIFY PLAYLIST', spotifyUrl)
-    // let attending = invitedUsers.some(invitedUser => invitedUser.id === user.id)
+
     return (
       <div>
         <br />
@@ -124,7 +111,7 @@ class PartyView extends React.Component {
                 itemsPerRow={3}
               >
                 {
-                  guestlist.length ?
+                  guestlist.length > 1 ?
                     guestlist.map(guest => {
                       return (
                         <GuestListItem key={guest.id} user={guest} eventId={eventId} />

--- a/client/store/newEvent.js
+++ b/client/store/newEvent.js
@@ -16,9 +16,12 @@ const getEvent = event => ({ type: GET_EVENT, event })
 /* THUNK CREATORS */
 export const createNewEvent = (createdEvent, history) =>
   dispatch => {
-    console.log("in event thunk")
-    SpotifyApi.setAccessToken(createdEvent.token)
-    SpotifyApi.createPlaylist(createdEvent.spotifyUserId, { name: createdEvent.name, public: true })
+    axios.get('/api/spotifyPlaylist/refreshtoken')
+    .then(res => {
+      const newToken = res.data
+      SpotifyApi.setAccessToken(newToken)
+     return SpotifyApi.createPlaylist(createdEvent.spotifyUserId, { name: createdEvent.name, public: true })
+    })
       .then((playlist) => {
         createdEvent.uri = playlist.uri
         createdEvent.playlistId = playlist.id

--- a/client/store/spotifyPlaylist.js
+++ b/client/store/spotifyPlaylist.js
@@ -54,7 +54,7 @@ export const updateSpotifyPlaylist = (eventId) =>
   }
 
 export const startSpotifyPlaylist = (spotifyUri) => {
-  axios.get('/api/spotifyPlaylist/play')
+  axios.get('/api/spotifyPlaylist/refreshtoken')
     .then(res => res.data)
     .then(token => {
       SpotifyApi.setAccessToken(token)

--- a/server/api/spotifyPlaylist.js
+++ b/server/api/spotifyPlaylist.js
@@ -58,6 +58,6 @@ router.get('/updatePlaylist/:eventId', tokenRefresh, (req, res, next) => { // Sh
         .catch(next)
 })
 
-router.get('/play/', tokenRefresh, (req, res, next) => {
+router.get('/refreshtoken/', tokenRefresh, (req, res, next) => {
     res.json(req.user.access)
 })


### PR DESCRIPTION
… and the bug where party view crashes for the host right after creating the playlist

### Assignee Tasks

- [ ] added unit tests (or none needed)
- [ ] written relevant docs (or none needed)
- [ ] referenced any relevant issues (or none exist)

- When creating a new playlist on spotify, its guaranteed to use a new access token. 
- When the user tries to view the event using the partyView, it will no longer crash the first time it loads.
